### PR TITLE
Provide an option to skip running async-profiler

### DIFF
--- a/jvm-blocking-monitor.py
+++ b/jvm-blocking-monitor.py
@@ -471,7 +471,7 @@ def sig_handler(signum, frame):
     global terminated
     terminated = True
 
-def main(ap_stream=None):
+def start_poll(ap_stream=None):
     b["events"].open_perf_buffer(print_event)
     while not terminated:
         if not pid_alive(args.tgid):
@@ -488,8 +488,8 @@ for sig in [signal.SIGTERM, signal.SIGINT, signal.SIGHUP]:
     signal.signal(sig, sig_handler)
 
 if args.skip_jvm_stack:
-    main()
+    start_poll()
 else:
     with AsyncProfiler(profiler_bin, args.tgid) as ap, \
             AsyncProfileStream(ap.output_path()) as ap_stream:
-        main(ap_stream)
+        start_poll(ap_stream)

--- a/jvm-blocking-monitor.py
+++ b/jvm-blocking-monitor.py
@@ -88,6 +88,8 @@ parser.add_argument("--state", type=positive_int,
          ") see include/linux/sched.h")
 parser.add_argument("--kernel3x", action="store_true",
                     help="3.x kernel mode. Signal for JVMTI agent will be sent from user process + some kprobe function signature adjust")
+parser.add_argument("--skip-jvm-stack", action="store_true",
+                    help="If this option is specified, jvm-blocking-monitor doesn't start async-profiler. Suitable if you want to run async-profiler externally")
 parser.add_argument("-o", "--output", action="store", default="-",
                     help="Base path of the file to output events")
 parser.add_argument("--discarded-events-output", action="store", default="-",
@@ -485,7 +487,7 @@ def main(ap_stream=None):
 for sig in [signal.SIGTERM, signal.SIGINT, signal.SIGHUP]:
     signal.signal(sig, sig_handler)
 
-if args.kernel_stacks_only:
+if args.skip_jvm_stack:
     main()
 else:
     with AsyncProfiler(profiler_bin, args.tgid) as ap, \


### PR DESCRIPTION
- Currently, jvm-blocking-monitor runs async-profiler internally for JVM stack joining
- If we want to run async-profiler externally (e.g. for ad-hoc profiling), this could be a problem
  * jvm-blocking-monitor starts async-profiler agent on the target process with `event=none && output=stream` mode.
  * This may cause conflict when we run another async-profiler on-the-fly to take other events (e.g. wallclock)
  * In this case, we want jvm-blocking-monitor not to run async-profiler